### PR TITLE
Set red as a 'warn' color

### DIFF
--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -56,7 +56,7 @@ $warn: (
   'A100': #ffffff,
   'A200': #ffffff,
   'A400': #ffffff,
-  'A700': #ffffff,
+  'A700': #ff0000,
   'contrastDefaultColor': #f4f4f4,
   'contrastLightColors': ('500', '600', '700', '800', '900'),
   'contrastStrongLightColors': ('500', '600', '700')


### PR DESCRIPTION
- since md-angular uses colors in 'warn' palette to decorate components with validation errors, replaced 'white' through 'red' for A700 color to avoid invalid fields becoming invisible.